### PR TITLE
Fix error when creating invoice

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -112,7 +112,7 @@
     <!-- Capture command -->
     <virtualType name="stripesofortCaptureCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
         <arguments>
-            <argument name="requestBuilder" xsi:type="object">Stripeofficial\Core\Gateway\Request\CaptureRequest</argument>
+            <argument name="requestBuilder" xsi:type="object">Stripeofficial\SOFORT\Gateway\Request\CaptureRequest</argument>
             <argument name="handler" xsi:type="object">Stripeofficial\Core\Gateway\Response\TxnIdHandler</argument>
             <argument name="transferFactory" xsi:type="object">Stripeofficial\Core\Gateway\Http\TransferFactory</argument>
             <argument name="validator" xsi:type="object">Stripeofficial\Core\Gateway\Validator\ResponseCodeValidator</argument>
@@ -121,11 +121,11 @@
     </virtualType>
 
     <!-- Capture Request -->
-    <type name="Stripeofficial\SOFORT\Gateway\Request\CaptureRequest">
+    <virtualType name="Stripeofficial\SOFORT\Gateway\Request\CaptureRequest" type="Stripeofficial\Core\Gateway\Request\CaptureRequest">
         <arguments>
             <argument name="config" xsi:type="object">stripesofortConfig</argument>
         </arguments>
-    </type>
+    </virtualType>
 
     <!-- Refund command -->
     <virtualType name="stripesofortRefundCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">


### PR DESCRIPTION
When manually creating invoice in Magento admin panel an error occurs "Cannot instantiate interface Magento\Payment\Gateway\ConfigInterface". This is because the config for `stripesofortCaptureCommand` uses Core Capture request object. This object requires `Magento\Payment\Gateway\ConfigInterface` class in its constructor but this is a generic interface that has no preference set in magento core. As there is another section in `di.xml` for `Stripeofficial\SOFORT\Gateway\Request\CaptureRequest` that is unused because neither there is a place in all codebase that uses such object nor such class exists. I propose to use it as a virtual type for `Stripeofficial\Core\Gateway\Request\CaptureRequest` with `config` param set for sofort config.